### PR TITLE
 Fix UI alignment and resize behavior for Graph Generator

### DIFF
--- a/src/components/GraphGenerator.tsx
+++ b/src/components/GraphGenerator.tsx
@@ -158,14 +158,15 @@ export const GraphGenerator: React.FC<GraphGeneratorProps> = ({ onGenerate, onGe
           value={edgesInput}
           onChange={(e) => setEdgesInput(e.target.value)}
           style={{
-            width: '100%',
+            width: 'calc(100% - 20px)',
             height: '60px',
             fontFamily: 'monospace',
             marginBottom: '5px',
             background: 'none',
             border: '1.5px solid var(--accent)',
             color: 'var(--text-primary)',
-            padding: '10px'
+            padding: '10px',
+            resize: 'vertical'
           }}
         /> <br />
 

--- a/src/index.css
+++ b/src/index.css
@@ -206,6 +206,8 @@ img {
 }
 
 .input-row label {
+    display: inline-block;
+    width: 100px;
     margin-right: 5px;
     font-size: 0.9em;
     color: #ccc;


### PR DESCRIPTION
### Summary
fxed ui alignment issues in the Graph Generator sidebar to keep the layout clean 

### Changes
- aligned inputs in the Generate Random Graphsection using fixed label widths
- limited edges textarea resizing to vertical only
- matched textarea width with other input fields

### The screenshot for the reference
<img width="525" height="335" alt="Screenshot 2026-01-03 at 11 08 58 PM" src="https://github.com/user-attachments/assets/feb4ebdb-8402-4847-a79f-8221af0f4a99" />

Closes #7 
CC: @Dwarakesh-V @Shyam-Sundar-Raju 
