### PR TITLE
[WoC] Prevent Duplicate Graph Names with Automatic Renaming

### DIFF
--- a/src/hooks/useGraphManager.ts
+++ b/src/hooks/useGraphManager.ts
@@ -13,10 +13,19 @@ export const useGraphManager = () => {
   // --- Actions ---
 
   const addGraph = (newGraph: Omit<GraphData, 'id'>) => {
-    const id = graphCount + 1;
-    const graphWithId = { ...newGraph, id, isVisible: true };
-    setGraphs(prev => [...prev, graphWithId]);
-    setGraphCount(id);
+    let finalName=newGraph.name.trim()||`Graph ${graphCount + 1}`;
+    const existingNames=graphs.map(g =>g.name);
+if (existingNames.includes(finalName)) {
+      let counter = 1;
+while (existingNames.includes(`${finalName}.${counter}`)) {
+        counter++;
+  }
+  finalName=`${finalName}.${counter}`;
+   }
+    const id=graphCount + 1;
+  const graphWithId={...newGraph, name:finalName, id, isVisible:true};
+ setGraphs(prev => [...prev, graphWithId]);
+   setGraphCount(id);
   };
 
   const removeGraph = (id: number) => {


### PR DESCRIPTION
- added automatic check for name collisions before creating graphs.
- implemented .1, .2 suffixing logic for duplicate names.
- ensures unique names for both manual and  therandom graph generation logicc.

The screenshot reference
<img width="793" height="602" alt="Screenshot 2026-01-04 at 12 12 59 AM" src="https://github.com/user-attachments/assets/4a10db0e-0612-40df-bd4b-0c5470ce71c3" />

This is for graph generation when no name is given it will see the count of how many grapsh have generated so far and add a count for that.
<img width="767" height="410" alt="Screenshot 2026-01-04 at 12 13 28 AM" src="https://github.com/user-attachments/assets/3c10e96a-e42a-4d46-af64-ae02a460c187" />

This is for generating a random graph it has a prefix of Random.
<img width="782" height="639" alt="Screenshot 2026-01-04 at 12 14 14 AM" src="https://github.com/user-attachments/assets/1174420f-09c8-403c-802f-271edf65bd3d" />

Closes #8 
CC: @Shyam-Sundar-Raju @Dwarakesh-V 

