### PR TITLE
[WOC] Feat: Add "Focus" option to center Graph Window in workspace

### DIFF
--- a/src/components/GraphWindow.tsx
+++ b/src/components/GraphWindow.tsx
@@ -491,6 +491,18 @@ export const GraphWindow: React.FC<GraphWindowProps> = ({
             {contextMenu.type === 'canvas' && (
               !isAddingNode ? (
                 <>
+                  <button onClick={() => {
+                    onFocus();
+                    const parent = containerRef.current?.closest('.main-workspace');
+                    if (parent) {
+                      const pW = parent.clientWidth;
+                      const pH = parent.clientHeight;
+                      const w = typeof position.width === 'number' ? position.width : 600;
+                      const h = typeof position.height === 'number' ? position.height : 450;
+                      setPosition({ ...position, x: (pW - w) / 2, y: (pH - h) / 2 });
+                    }
+                    setContextMenu(null);
+                  }}>Focus</button>
                   <button onClick={() => setIsAddingNode(true)}>Add Vertex</button>
                   <hr style={{ border: 'none', borderTop: '1px solid #444', margin: '4px 0' }} />
                   <button onClick={handleSavePNG}>Save as PNG</button>


### PR DESCRIPTION
### Summary of Changes
this pr introduces a new Focus option to the graph window context menu, allowing users to quickly center a window within the workspace.

### Key Deliverables:
1. Focus Option: added a new "Focus" button to the canvas context menu on right-click on the graph background).
2. Auto-Centering Logic*: When clicked, the window is brought to the front and its position is recalculated to be perfectly centered within its parent workspace.
3. Optimized Implementation: Used existing state management (`setPosition`) and DOM traversal (`closest('.main-workspace')`) to ensure the fix is lightweight and consistent with the existing codebase.

Screenshot
<img width="247" height="219" alt="Screenshot 2026-01-04 at 11 44 07 AM" src="https://github.com/user-attachments/assets/da0dd452-f68c-40fb-8c7c-98a7ef7a305b" />

Closes #16 
CC: @Dwarakesh-V 